### PR TITLE
Adding support for inline chat

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,8 @@ var Olark = module.exports = integration('Olark')
   .option('listen', false)
   .option('page', true)
   .option('siteId', '')
-  .option('track', false);
+  .option('track', false)
+  .option('inline', false);
 
 /**
  * The context for this integration.
@@ -68,6 +69,10 @@ Olark.prototype.load = function(callback) {
   /* eslint-disable */
   window.olark||(function(c){var f=window,d=document,l=https()?"https:":"http:",z=c.name,r="load";var nt=function(){f[z]=function(){(a.s=a.s||[]).push(arguments)};var a=f[z]._={},q=c.methods.length;while (q--) {(function(n){f[z][n]=function(){f[z]("call",n,arguments)}})(c.methods[q])}a.l=c.loader;a.i=nt;a.p={ 0:+new Date() };a.P=function(u){a.p[u]=new Date()-a.p[0]};function s(){a.P(r);f[z](r)}f.addEventListener?f.addEventListener(r,s,false):f.attachEvent("on"+r,s);var ld=function(){function p(hd){hd="head";return ["<",hd,"></",hd,"><",i,' onl' + 'oad="var d=',g,";d.getElementsByTagName('head')[0].",j,"(d.",h,"('script')).",k,"='",l,"//",a.l,"'",'"',"></",i,">"].join("")}var i="body",m=d[i];if (!m) {return setTimeout(ld,100)}a.P(1);var j="appendChild",h="createElement",k="src",n=d[h]("div"),v=n[j](d[h](z)),b=d[h]("iframe"),g="document",e="domain",o;n.style.display="none";m.insertBefore(n,m.firstChild).id=z;b.frameBorder="0";b.id=z+"-loader";if (/MSIE[ ]+6/.test(navigator.userAgent)) {b.src="javascript:false"}b.allowTransparency="true";v[j](b);try {b.contentWindow[g].open()}catch (w) {c[e]=d[e];o="javascript:var d="+g+".open();d.domain='"+d.domain+"';";b[k]=o+"void(0);"}try {var t=b.contentWindow[g];t.write(p());t.close()}catch (x) {b[k]=o+'d.write("'+p().replace(/"/g,String.fromCharCode(92)+'"')+'");d.close();'}a.P(2)};ld()};nt()})({ loader: "static.olark.com/jsclient/loader0.js", name:"olark", methods:["configure","extend","declare","identify"] });
   /* eslint-enable */
+
+  // check if chat should be loaded as `inline chat`
+  if (this.options.inline) configure('box.inline', true);
+
   window.olark.identify(this.options.siteId);
   callback();
 };
@@ -204,4 +209,8 @@ Olark.prototype.notify = function(message) {
 
 function api(action, value) {
   window.olark('api.' + action, value);
+}
+
+function configure(action, value) {
+  window.olark.configure(action, value);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,7 +41,8 @@ describe('Olark', function() {
       .option('listen', false)
       .option('page', true)
       .option('siteId', '')
-      .option('track', false));
+      .option('track', false)
+      .option('inline', false));
   });
 
   describe('before loading', function() {
@@ -65,6 +66,26 @@ describe('Olark', function() {
   describe('loading', function() {
     it('should load', function(done) {
       analytics.load(olark, done);
+    });
+  });
+
+  describe('loading inline', function() {
+    beforeEach(function() {
+      analytics.spy(window.olark, 'configure');
+    });
+
+    it('should pass in inline chat to `configure` if set', function() {
+      olark.options.inline = true;
+      analytics.initialize();
+      analytics.page();
+      analytics.called(window.olark.configure, 'box.inline', true);
+    });
+
+    it('should not pass in inline chat to `configure` if not set', function() {
+      olark.options.inline = false;
+      analytics.initialize();
+      analytics.page();
+      analytics.didNotCall(window.olark.configure, 'box.inline');
     });
   });
 


### PR DESCRIPTION
This adds in support for loading as inline chat, with the default set to false to not affect existing users.

Tests added to confirm the setting is passed through if it's set to true, but not if it's set to false.

This will require a new setting to be toggled by the account owner at segment.com for setting the chat to inline chat mode.
