### PR TITLE
Preventing tracking for olark events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -155,7 +155,10 @@ Olark.prototype.attachListeners = function() {
     self.analytics.track(
       'Live Chat Conversation Started',
       {},
-      { context: { integration: integrationContext } }
+      {
+        context: { integration: integrationContext },
+        integrations: { Olark: false }
+      }
     );
   });
 
@@ -165,7 +168,10 @@ Olark.prototype.attachListeners = function() {
     self.analytics.track(
       'Live Chat Message Sent',
       {},
-      { context: { integration: integrationContext } }
+      {
+        context: { integration: integrationContext },
+        integrations: { Olark: false }
+      }
     );
   });
 
@@ -175,7 +181,10 @@ Olark.prototype.attachListeners = function() {
     self.analytics.track(
       'Live Chat Message Received',
       {},
-      { context: { integration: integrationContext } }
+      {
+        context: { integration: integrationContext },
+        integrations: { Olark: false }
+      }
     );
   });
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -323,7 +323,7 @@ describe('Olark', function() {
       it('should send a chat started event', function(done) {
         window.olark('api.chat.sendMessageToVisitor', { body: 'hello' });
         setTimeout(function() {
-          analytics.called(analytics.track, 'Live Chat Conversation Started', {}, { context: { integration: { name: 'olark', version: '1.0.0' } } });
+          analytics.called(analytics.track, 'Live Chat Conversation Started', {}, { context: { integration: { name: 'olark', version: '1.0.0' } }, integrations: { Olark: false } });
           done();
         }, 3000);
       });
@@ -335,7 +335,7 @@ describe('Olark', function() {
       it('should send a chat sent event', function(done) {
         window.olark('api.chat.sendMessageToVisitor', { body: 'hi, PLEASE RESPOND' });
         setTimeout(function() {
-          analytics.called(analytics.track, 'Live Chat Message Sent', { messageBody: 'hi' }, { context: { integration: { name: 'olark', version: '1.0.0' }}});
+          analytics.called(analytics.track, 'Live Chat Message Sent', { messageBody: 'hi' }, { context: { integration: { name: 'olark', version: '1.0.0' }}, integrations: { Olark: false }});
           done();
         }, 5000);
       });**/
@@ -343,7 +343,7 @@ describe('Olark', function() {
       it('should send a chat received event', function(done) {
         window.olark('api.chat.sendMessageToVisitor', { body: 'oh hai' });
         setTimeout(function() {
-          analytics.called(analytics.track, 'Live Chat Message Received', {}, { context: { integration: { name: 'olark', version: '1.0.0' } } });
+          analytics.called(analytics.track, 'Live Chat Message Received', {}, { context: { integration: { name: 'olark', version: '1.0.0' } }, integrations: { Olark: false } });
           done();
         }, 3000);
       });


### PR DESCRIPTION
Adds a check to see if the caller of a Track event is olark and if it is, ignore it.
If we don't do this operators get bombarded with quite a lot of event messages while chatting with people.
